### PR TITLE
Re-organise code to facilitate future improvements

### DIFF
--- a/nbstripout/__init__.py
+++ b/nbstripout/__init__.py
@@ -1,5 +1,6 @@
-from ._nbstripout import install, uninstall, status, main, __doc__ as docstring
-from ._utils import pop_recursive, strip_output, MetadataError
+from ._nbstripout import main, __doc__ as docstring
+from ._installer import install, uninstall, status
+from ._utils import pop_recursive, strip_output, StripArgs, MetadataError
 __all__ = ["install", "uninstall", "status", "main",
-           "pop_recursive", "strip_output", "MetadataError"]
+           "pop_recursive", "strip_output", "StripArgs", "MetadataError"]
 __doc__ = docstring

--- a/nbstripout/_installer.py
+++ b/nbstripout/_installer.py
@@ -11,6 +11,7 @@ INSTALL_LOCATION_LOCAL = 'local'
 INSTALL_LOCATION_GLOBAL = 'global'
 INSTALL_LOCATION_SYSTEM = 'system'
 
+
 def _get_system_gitconfig_folder():
     try:
         git_config_output = check_output(['git', 'config', '--system', '--list', '--show-origin'], universal_newlines=True, stderr=STDOUT).strip()

--- a/nbstripout/_installer.py
+++ b/nbstripout/_installer.py
@@ -1,0 +1,195 @@
+from os import devnull, environ, makedirs, path
+from pathlib import PureWindowsPath
+import re
+from subprocess import call, check_call, check_output, CalledProcessError, STDOUT
+import sys
+
+__all__ = ["install", "uninstall", "status", "INSTALL_LOCATION_LOCAL", "INSTALL_LOCATION_GLOBAL", "INSTALL_LOCATION_SYSTEM"]
+
+
+INSTALL_LOCATION_LOCAL = 'local'
+INSTALL_LOCATION_GLOBAL = 'global'
+INSTALL_LOCATION_SYSTEM = 'system'
+
+def _get_system_gitconfig_folder():
+    try:
+        git_config_output = check_output(['git', 'config', '--system', '--list', '--show-origin'], universal_newlines=True, stderr=STDOUT).strip()
+
+        # If the output is empty, it means the file exists but is empty, so we cannot get the path.
+        # To still get it, we're setting a temporary config parameter.
+        if git_config_output == '':
+            check_call(['git', 'config', '--system', 'filter.nbstripoutput.test', 'test'])
+            git_config_output = check_output(['git', 'config', '--system', '--list', '--show-origin'], universal_newlines=True).strip()
+            check_call(['git', 'config', '--system', '--unset', 'filter.nbstripoutput.test'])
+
+        output_lines = git_config_output.split('\n')
+
+        system_gitconfig_file_path = re.sub(r'^file:', '', output_lines[0].split('\t')[0])
+    except CalledProcessError as e:
+        git_config_output = e.output
+
+        system_gitconfig_file_path = re.match(r"fatal:.*file '([^']+)'.*", git_config_output).group(1)
+
+    return path.abspath(path.dirname(system_gitconfig_file_path))
+
+
+def _get_attrfile(git_config, install_location=INSTALL_LOCATION_LOCAL, attrfile=None):
+    if not attrfile:
+        if install_location == INSTALL_LOCATION_SYSTEM:
+            try:
+                attrfile = check_output(git_config + ['core.attributesFile'], universal_newlines=True).strip()
+            except CalledProcessError:
+                config_dir = _get_system_gitconfig_folder()
+                attrfile = path.join(config_dir, 'gitattributes')
+        elif install_location == INSTALL_LOCATION_GLOBAL:
+            try:
+                attrfile = check_output(git_config + ['core.attributesFile'], universal_newlines=True).strip()
+            except CalledProcessError:
+                config_dir = environ.get('XDG_CONFIG_DIR', path.expanduser('~/.config'))
+                attrfile = path.join(config_dir, 'git', 'attributes')
+        else:
+            git_dir = check_output(['git', 'rev-parse', '--git-dir'], universal_newlines=True).strip()
+            attrfile = path.join(git_dir, 'info', 'attributes')
+
+    attrfile = path.expanduser(attrfile)
+    if path.dirname(attrfile):
+        makedirs(path.dirname(attrfile), exist_ok=True)
+
+    return attrfile
+
+
+def install(git_config, install_location=INSTALL_LOCATION_LOCAL, attrfile=None):
+    """Install the git filter and set the git attributes."""
+    try:
+        filepath = f'"{PureWindowsPath(sys.executable).as_posix()}" -m nbstripout'
+        check_call(git_config + ['filter.nbstripout.clean', filepath])
+        check_call(git_config + ['filter.nbstripout.smudge', 'cat'])
+        check_call(git_config + ['diff.ipynb.textconv', filepath + ' -t'])
+        attrfile = _get_attrfile(git_config, install_location, attrfile)
+    except FileNotFoundError:
+        print('Installation failed: git is not on path!', file=sys.stderr)
+        return 1
+    except CalledProcessError:
+        print('Installation failed: not a git repository!', file=sys.stderr)
+        return 1
+
+    # Check if there is already a filter for ipynb files
+    filt_exists = False
+    zeppelin_filt_exists = False
+    diff_exists = False
+
+    if path.exists(attrfile):
+        with open(attrfile, 'r') as f:
+            attrs = f.read()
+
+        filt_exists = '*.ipynb filter' in attrs
+        zeppelin_filt_exists = '*.zpln filter' in attrs
+        diff_exists = '*.ipynb diff' in attrs
+
+        if filt_exists and diff_exists:
+            return
+
+    try:
+        with open(attrfile, 'a', newline='') as f:
+            # If the file already exists, ensure it ends with a new line
+            if f.tell():
+                f.write('\n')
+            if not filt_exists:
+                print('*.ipynb filter=nbstripout', file=f)
+            if not zeppelin_filt_exists:
+                print('*.zpln filter=nbstripout', file=f)
+            if not diff_exists:
+                print('*.ipynb diff=ipynb', file=f)
+    except PermissionError:
+        print(f'Installation failed: could not write to {attrfile}', file=sys.stderr)
+
+        if install_location == INSTALL_LOCATION_GLOBAL:
+            print('Did you forget to sudo?', file=sys.stderr)
+
+        return 1
+
+
+def uninstall(git_config, install_location=INSTALL_LOCATION_LOCAL, attrfile=None):
+    """Uninstall the git filter and unset the git attributes."""
+    try:
+        call(git_config + ['--unset', 'filter.nbstripout.clean'], stdout=open(devnull, 'w'), stderr=STDOUT)
+        call(git_config + ['--unset', 'filter.nbstripout.smudge'], stdout=open(devnull, 'w'), stderr=STDOUT)
+        call(git_config + ['--remove-section', 'diff.ipynb'], stdout=open(devnull, 'w'), stderr=STDOUT)
+        attrfile = _get_attrfile(git_config, install_location, attrfile)
+    except FileNotFoundError:
+        print('Uninstall failed: git is not on path!', file=sys.stderr)
+        return 1
+    except CalledProcessError:
+        print('Uninstall failed: not a git repository!', file=sys.stderr)
+        return 1
+
+    # Check if there is a filter for ipynb files
+    if path.exists(attrfile):
+        with open(attrfile, 'r+') as f:
+            patterns = ('*.ipynb filter', '*.zpln filter', '*.ipynb diff')
+            lines = [line for line in f if not any(line.startswith(p) for p in patterns)]
+            f.seek(0)
+            f.write(''.join(lines))
+            f.truncate()
+
+
+def status(git_config, install_location=INSTALL_LOCATION_LOCAL, verbose=False):
+    """Return 0 if nbstripout is installed in the current repo, 1 otherwise"""
+    try:
+        if install_location == INSTALL_LOCATION_SYSTEM:
+            location = 'system-wide'
+        elif install_location == INSTALL_LOCATION_GLOBAL:
+            location = 'globally'
+        else:
+            git_dir = path.dirname(path.abspath(check_output(['git', 'rev-parse', '--git-dir'], universal_newlines=True).strip()))
+            location = f"in repository '{git_dir}'"
+
+        clean = check_output(git_config + ['filter.nbstripout.clean'], universal_newlines=True).strip()
+        smudge = check_output(git_config + ['filter.nbstripout.smudge'], universal_newlines=True).strip()
+        diff = check_output(git_config + ['diff.ipynb.textconv'], universal_newlines=True).strip()
+
+        if install_location in {INSTALL_LOCATION_SYSTEM, INSTALL_LOCATION_GLOBAL}:
+            attrfile = _get_attrfile(git_config, install_location)
+            attributes = ''
+            diff_attributes = ''
+
+            if path.exists(attrfile):
+                with open(attrfile, 'r') as f:
+                    attrs = f.readlines()
+                attributes = ''.join(line for line in attrs if 'filter' in line).strip()
+                diff_attributes = ''.join(line for line in attrs if 'diff' in line).strip()
+        else:
+            attributes = check_output(['git', 'check-attr', 'filter', '--', '*.ipynb'], universal_newlines=True).strip()
+            diff_attributes = check_output(['git', 'check-attr', 'diff', '--', '*.ipynb'], universal_newlines=True).strip()
+
+        try:
+            extra_keys = check_output(git_config + ['filter.nbstripout.extrakeys'], universal_newlines=True).strip()
+        except CalledProcessError:
+            extra_keys = ''
+
+        if attributes.endswith('unspecified'):
+            if verbose:
+                print('nbstripout is not installed', location)
+
+            return 1
+
+        if verbose:
+            print('nbstripout is installed', location)
+            print('\nFilter:')
+            print('  clean =', clean)
+            print('  smudge =', smudge)
+            print('  diff=', diff)
+            print('  extrakeys=', extra_keys)
+            print('\nAttributes:\n ', attributes)
+            print('\nDiff Attributes:\n ', diff_attributes)
+
+        return 0
+    except FileNotFoundError:
+        print('Cannot determine status: git is not on path!', file=sys.stderr)
+
+        return 1
+    except CalledProcessError:
+        if verbose and 'location' in locals():
+            print('nbstripout is not installed', location)
+
+        return 1

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -113,14 +113,14 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import collections
 import io
 import json
-from os import devnull, environ, makedirs, path
-from pathlib import PureWindowsPath
-import re
-from subprocess import call, check_call, check_output, CalledProcessError, STDOUT
+from subprocess import check_output, CalledProcessError
 import sys
+from typing import TextIO
 import warnings
 
-from nbstripout._utils import strip_output, strip_zeppelin_output
+from nbstripout._utils import strip_output, strip_zeppelin_output, StripArgs
+from nbstripout._installer import install, uninstall, status, INSTALL_LOCATION_LOCAL, INSTALL_LOCATION_GLOBAL, INSTALL_LOCATION_SYSTEM
+
 try:
     # Jupyter >= 4
     from nbformat import read, write, NO_CONVERT
@@ -144,60 +144,8 @@ except ImportError:
         def write(nb, f):
             return current.write(nb, f, 'json')
 
-__all__ = ["install", "uninstall", "status", "main"]
+__all__ = ["main", "process_stream"]
 __version__ = '0.6.1'
-
-
-INSTALL_LOCATION_LOCAL = 'local'
-INSTALL_LOCATION_GLOBAL = 'global'
-INSTALL_LOCATION_SYSTEM = 'system'
-
-
-def _get_system_gitconfig_folder():
-    try:
-        git_config_output = check_output(['git', 'config', '--system', '--list', '--show-origin'], universal_newlines=True, stderr=STDOUT).strip()
-
-        # If the output is empty, it means the file exists but is empty, so we cannot get the path.
-        # To still get it, we're setting a temporary config parameter.
-        if git_config_output == '':
-            check_call(['git', 'config', '--system', 'filter.nbstripoutput.test', 'test'])
-            git_config_output = check_output(['git', 'config', '--system', '--list', '--show-origin'], universal_newlines=True).strip()
-            check_call(['git', 'config', '--system', '--unset', 'filter.nbstripoutput.test'])
-
-        output_lines = git_config_output.split('\n')
-
-        system_gitconfig_file_path = re.sub(r'^file:', '', output_lines[0].split('\t')[0])
-    except CalledProcessError as e:
-        git_config_output = e.output
-
-        system_gitconfig_file_path = re.match(r"fatal:.*file '([^']+)'.*", git_config_output).group(1)
-
-    return path.abspath(path.dirname(system_gitconfig_file_path))
-
-
-def _get_attrfile(git_config, install_location=INSTALL_LOCATION_LOCAL, attrfile=None):
-    if not attrfile:
-        if install_location == INSTALL_LOCATION_SYSTEM:
-            try:
-                attrfile = check_output(git_config + ['core.attributesFile'], universal_newlines=True).strip()
-            except CalledProcessError:
-                config_dir = _get_system_gitconfig_folder()
-                attrfile = path.join(config_dir, 'gitattributes')
-        elif install_location == INSTALL_LOCATION_GLOBAL:
-            try:
-                attrfile = check_output(git_config + ['core.attributesFile'], universal_newlines=True).strip()
-            except CalledProcessError:
-                config_dir = environ.get('XDG_CONFIG_DIR', path.expanduser('~/.config'))
-                attrfile = path.join(config_dir, 'git', 'attributes')
-        else:
-            git_dir = check_output(['git', 'rev-parse', '--git-dir'], universal_newlines=True).strip()
-            attrfile = path.join(git_dir, 'info', 'attributes')
-
-    attrfile = path.expanduser(attrfile)
-    if path.dirname(attrfile):
-        makedirs(path.dirname(attrfile), exist_ok=True)
-
-    return attrfile
 
 
 def _parse_size(num_str):
@@ -212,143 +160,6 @@ def _parse_size(num_str):
         return int(num_str[:-1]) * (10**9)
     else:
         raise ValueError(f"Unknown size identifier {num_str[-1]}")
-
-
-def install(git_config, install_location=INSTALL_LOCATION_LOCAL, attrfile=None):
-    """Install the git filter and set the git attributes."""
-    try:
-        filepath = f'"{PureWindowsPath(sys.executable).as_posix()}" -m nbstripout'
-        check_call(git_config + ['filter.nbstripout.clean', filepath])
-        check_call(git_config + ['filter.nbstripout.smudge', 'cat'])
-        check_call(git_config + ['diff.ipynb.textconv', filepath + ' -t'])
-        attrfile = _get_attrfile(git_config, install_location, attrfile)
-    except FileNotFoundError:
-        print('Installation failed: git is not on path!', file=sys.stderr)
-        return 1
-    except CalledProcessError:
-        print('Installation failed: not a git repository!', file=sys.stderr)
-        return 1
-
-    # Check if there is already a filter for ipynb files
-    filt_exists = False
-    zeppelin_filt_exists = False
-    diff_exists = False
-
-    if path.exists(attrfile):
-        with open(attrfile, 'r') as f:
-            attrs = f.read()
-
-        filt_exists = '*.ipynb filter' in attrs
-        zeppelin_filt_exists = '*.zpln filter' in attrs
-        diff_exists = '*.ipynb diff' in attrs
-
-        if filt_exists and diff_exists:
-            return
-
-    try:
-        with open(attrfile, 'a', newline='') as f:
-            # If the file already exists, ensure it ends with a new line
-            if f.tell():
-                f.write('\n')
-            if not filt_exists:
-                print('*.ipynb filter=nbstripout', file=f)
-            if not zeppelin_filt_exists:
-                print('*.zpln filter=nbstripout', file=f)
-            if not diff_exists:
-                print('*.ipynb diff=ipynb', file=f)
-    except PermissionError:
-        print(f'Installation failed: could not write to {attrfile}', file=sys.stderr)
-
-        if install_location == INSTALL_LOCATION_GLOBAL:
-            print('Did you forget to sudo?', file=sys.stderr)
-
-        return 1
-
-
-def uninstall(git_config, install_location=INSTALL_LOCATION_LOCAL, attrfile=None):
-    """Uninstall the git filter and unset the git attributes."""
-    try:
-        call(git_config + ['--unset', 'filter.nbstripout.clean'], stdout=open(devnull, 'w'), stderr=STDOUT)
-        call(git_config + ['--unset', 'filter.nbstripout.smudge'], stdout=open(devnull, 'w'), stderr=STDOUT)
-        call(git_config + ['--remove-section', 'diff.ipynb'], stdout=open(devnull, 'w'), stderr=STDOUT)
-        attrfile = _get_attrfile(git_config, install_location, attrfile)
-    except FileNotFoundError:
-        print('Uninstall failed: git is not on path!', file=sys.stderr)
-        return 1
-    except CalledProcessError:
-        print('Uninstall failed: not a git repository!', file=sys.stderr)
-        return 1
-
-    # Check if there is a filter for ipynb files
-    if path.exists(attrfile):
-        with open(attrfile, 'r+') as f:
-            patterns = ('*.ipynb filter', '*.zpln filter', '*.ipynb diff')
-            lines = [line for line in f if not any(line.startswith(p) for p in patterns)]
-            f.seek(0)
-            f.write(''.join(lines))
-            f.truncate()
-
-
-def status(git_config, install_location=INSTALL_LOCATION_LOCAL, verbose=False):
-    """Return 0 if nbstripout is installed in the current repo, 1 otherwise"""
-    try:
-        if install_location == INSTALL_LOCATION_SYSTEM:
-            location = 'system-wide'
-        elif install_location == INSTALL_LOCATION_GLOBAL:
-            location = 'globally'
-        else:
-            git_dir = path.dirname(path.abspath(check_output(['git', 'rev-parse', '--git-dir'], universal_newlines=True).strip()))
-            location = f"in repository '{git_dir}'"
-
-        clean = check_output(git_config + ['filter.nbstripout.clean'], universal_newlines=True).strip()
-        smudge = check_output(git_config + ['filter.nbstripout.smudge'], universal_newlines=True).strip()
-        diff = check_output(git_config + ['diff.ipynb.textconv'], universal_newlines=True).strip()
-
-        if install_location in {INSTALL_LOCATION_SYSTEM, INSTALL_LOCATION_GLOBAL}:
-            attrfile = _get_attrfile(git_config, install_location)
-            attributes = ''
-            diff_attributes = ''
-
-            if path.exists(attrfile):
-                with open(attrfile, 'r') as f:
-                    attrs = f.readlines()
-                attributes = ''.join(line for line in attrs if 'filter' in line).strip()
-                diff_attributes = ''.join(line for line in attrs if 'diff' in line).strip()
-        else:
-            attributes = check_output(['git', 'check-attr', 'filter', '--', '*.ipynb'], universal_newlines=True).strip()
-            diff_attributes = check_output(['git', 'check-attr', 'diff', '--', '*.ipynb'], universal_newlines=True).strip()
-
-        try:
-            extra_keys = check_output(git_config + ['filter.nbstripout.extrakeys'], universal_newlines=True).strip()
-        except CalledProcessError:
-            extra_keys = ''
-
-        if attributes.endswith('unspecified'):
-            if verbose:
-                print('nbstripout is not installed', location)
-
-            return 1
-
-        if verbose:
-            print('nbstripout is installed', location)
-            print('\nFilter:')
-            print('  clean =', clean)
-            print('  smudge =', smudge)
-            print('  diff=', diff)
-            print('  extrakeys=', extra_keys)
-            print('\nAttributes:\n ', attributes)
-            print('\nDiff Attributes:\n ', diff_attributes)
-
-        return 0
-    except FileNotFoundError:
-        print('Cannot determine status: git is not on path!', file=sys.stderr)
-
-        return 1
-    except CalledProcessError:
-        if verbose and 'location' in locals():
-            print('nbstripout is not installed', location)
-
-        return 1
 
 
 def main():
@@ -446,89 +257,117 @@ def main():
 
     extra_keys.extend(args.extra_keys.split())
 
-    # Wrap input/output stream in UTF-8 encoded text wrapper
-    # https://stackoverflow.com/a/16549381
-    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8') if sys.stdin else None
-    output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', newline='')
+    strip_args = StripArgs(args.keep_output, args.keep_count, extra_keys, args.drop_empty_cells,
+                    args.drop_tagged_cells.split(), args.strip_init_cells, _parse_size(args.max_size))
 
-    for filename in args.files:
-        if not (args.force or filename.endswith('.ipynb') or filename.endswith('.zpln')):
-            continue
-
-        try:
-            with io.open(filename, 'r', encoding='utf8') as f:
-                if args.mode == 'zeppelin' or filename.endswith('.zpln'):
-                    if args.dry_run:
-                        output_stream.write(f'Dry run: would have stripped {filename}\n')
-                        continue
-                    nb = json.load(f, object_pairs_hook=collections.OrderedDict)
-                    nb_stripped = strip_zeppelin_output(nb)
-
-                    with open(filename, 'w') as f:
-                        json.dump(nb_stripped, f, indent=2)
-                    continue
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", category=UserWarning)
-                    nb = read(f, as_version=NO_CONVERT)
-
-            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.drop_empty_cells,
-                              args.drop_tagged_cells.split(), args.strip_init_cells, _parse_size(args.max_size))
-
-            if args.dry_run:
-                output_stream.write(f'Dry run: would have stripped {filename}\n')
-
+    if args.files:
+        for filename in args.files:
+            if not (args.force or filename.endswith('.ipynb') or filename.endswith('.zpln')):
                 continue
+            process_file(filename, args.mode, args.dry_run, args.textconv, strip_args)
+    else:
+        process_stream(strip_args)
 
-            if args.textconv:
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", category=UserWarning)
-                    write(nb, output_stream)
 
-                output_stream.flush()
-            else:
-                with io.open(filename, 'w', encoding='utf8', newline='') as f:
-                    with warnings.catch_warnings():
-                        warnings.simplefilter("ignore", category=UserWarning)
-                        write(nb, f)
-        except NotJSONError:
-            print(f"'{filename}' is not a valid notebook", file=sys.stderr)
-            raise SystemExit(1)
-        except FileNotFoundError:
-            print(f"Could not strip '{filename}': file not found", file=sys.stderr)
-            raise SystemExit(1)
-        except Exception:
-            # Ignore exceptions for non-notebook files.
-            print(f"Could not strip '{filename}'", file=sys.stderr)
-            raise
-
-    if not args.files and input_stream:
-        try:
-            if args.mode == 'zeppelin':
-                if args.dry_run:
-                    output_stream.write('Dry run: would have stripped input from stdin\n')
-                    raise SystemExit(0)
-                nb = json.load(input_stream, object_pairs_hook=collections.OrderedDict)
+def process_file(filename, mode: str, dry_run: bool, textconv: bool, strip_args: StripArgs):
+    try:
+        with io.open(filename, 'r', encoding='utf8') as f:
+            if mode == 'zeppelin' or filename.endswith('.zpln'):
+                if dry_run:
+                    sys.stderr.write(f'Dry run: would have stripped {filename}\n')
+                    return
+                nb = json.load(f, object_pairs_hook=collections.OrderedDict)
                 nb_stripped = strip_zeppelin_output(nb)
-                json.dump(nb_stripped, output_stream, indent=2)
-                output_stream.write('\n')
-                output_stream.flush()
-                raise SystemExit(0)
+
+                with open(filename, 'w') as f:
+                    json.dump(nb_stripped, f, indent=2)
+                return
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=UserWarning)
-                nb = read(input_stream, as_version=NO_CONVERT)
+                nb = read(f, as_version=NO_CONVERT)
 
-            nb = strip_output(nb, args.keep_output, args.keep_count, extra_keys, args.drop_empty_cells,
-                              args.drop_tagged_cells.split(), args.strip_init_cells, _parse_size(args.max_size))
+        nb = strip_output(nb, strip_args)
 
-            if args.dry_run:
-                output_stream.write('Dry run: would have stripped input from '
-                                    'stdin\n')
-            else:
+        if dry_run:
+            sys.stderr.write(f'Dry run: would have stripped {filename}\n')
+
+            return
+
+        if textconv:
+            output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', newline='')
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=UserWarning)
+                write(nb, output_stream)
+            output_stream.flush()
+        else:
+            with io.open(filename, 'w', encoding='utf8', newline='') as f:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", category=UserWarning)
-                    write(nb, output_stream)
+                    write(nb, f)
+    except NotJSONError:
+        print(f"'{filename}' is not a valid notebook", file=sys.stderr)
+        raise SystemExit(1)
+    except FileNotFoundError:
+        print(f"Could not strip '{filename}': file not found", file=sys.stderr)
+        raise SystemExit(1)
+    except Exception:
+        # Ignore exceptions for non-notebook files.
+        print(f"Could not strip '{filename}'", file=sys.stderr)
+        raise
 
-                output_stream.flush()
-        except NotJSONError:
-            print('No valid notebook detected', file=sys.stderr)
-            raise SystemExit(1)
+def process_stream(force: bool, mode: str, dry_run: bool, textconv: bool, strip_args: StripArgs):
+    if not sys.stdin:
+        raise ValueError("No files supplied, and could not open STDIN for reading")
+
+    # Wrap input/output stream in UTF-8 encoded text wrapper
+    # https://stackoverflow.com/a/16549381
+    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+    output_stream = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', newline='')
+
+    try:
+        if mode == 'zeppelin':
+            if dry_run:
+                sys.stderr.write('Dry run: would have stripped input from stdin\n')
+                raise SystemExit(0)
+            nb = json.load(input_stream, object_pairs_hook=collections.OrderedDict)
+            nb_stripped = strip_zeppelin_output(nb)
+            json.dump(nb_stripped, output_stream, indent=2)
+            output_stream.write('\n')
+            output_stream.flush()
+            raise SystemExit(0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            nb = read(input_stream, as_version=NO_CONVERT)
+
+        nb = strip_output(nb, strip_args)
+
+        if dry_run:
+            output_stream.write('Dry run: would have stripped input from '
+                                'stdin\n')
+        else:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=UserWarning)
+                write(nb, output_stream)
+
+            output_stream.flush()
+    except NotJSONError:
+        print('No valid notebook detected', file=sys.stderr)
+        raise SystemExit(1)
+
+def load_zepellin(input_stream: TextIO):
+    return json.load(input_stream, object_pairs_hook=collections.OrderedDict)
+
+def write_zepellin(nb, output_stream: TextIO):
+    json.dump(nb, output_stream, indent=2)
+    output_stream.flush()
+    
+def load_jupyter(input_stream: TextIO):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        return read(input_stream, as_version=NO_CONVERT)
+
+def write_jupyter(nb, output_stream: TextIO):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        write(nb, output_stream)
+    output_stream.flush()

--- a/nbstripout/_nbstripout.py
+++ b/nbstripout/_nbstripout.py
@@ -257,8 +257,7 @@ def main():
 
     extra_keys.extend(args.extra_keys.split())
 
-    strip_args = StripArgs(args.keep_output, args.keep_count, extra_keys, args.drop_empty_cells,
-                    args.drop_tagged_cells.split(), args.strip_init_cells, _parse_size(args.max_size))
+    strip_args = StripArgs(args.keep_output, args.keep_count, extra_keys, args.drop_empty_cells, args.drop_tagged_cells.split(), args.strip_init_cells, _parse_size(args.max_size))
 
     if args.files:
         for filename in args.files:
@@ -315,6 +314,7 @@ def process_file(filename, mode: str, dry_run: bool, textconv: bool, strip_args:
         print(f"Could not strip '{filename}'", file=sys.stderr)
         raise
 
+
 def process_stream(force: bool, mode: str, dry_run: bool, textconv: bool, strip_args: StripArgs):
     if not sys.stdin:
         raise ValueError("No files supplied, and could not open STDIN for reading")
@@ -354,17 +354,21 @@ def process_stream(force: bool, mode: str, dry_run: bool, textconv: bool, strip_
         print('No valid notebook detected', file=sys.stderr)
         raise SystemExit(1)
 
+
 def load_zepellin(input_stream: TextIO):
     return json.load(input_stream, object_pairs_hook=collections.OrderedDict)
+
 
 def write_zepellin(nb, output_stream: TextIO):
     json.dump(nb, output_stream, indent=2)
     output_stream.flush()
-    
+
+
 def load_jupyter(input_stream: TextIO):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         return read(input_stream, as_version=NO_CONVERT)
+
 
 def write_jupyter(nb, output_stream: TextIO):
     with warnings.catch_warnings():

--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -9,6 +9,7 @@ __all__ = ["pop_recursive", "strip_output", "strip_zeppelin_output", "StripArgs"
 class MetadataError(Exception):
     pass
 
+
 class StripArgs(NamedTuple):
     keep_output: bool
     keep_count: bool
@@ -16,7 +17,7 @@ class StripArgs(NamedTuple):
     drop_empty_cells: bool = False
     drop_tagged_cells: List[str] = []
     strip_init_cells: bool = False
-    max_size:int = 0
+    max_size: int = 0
 
 
 def pop_recursive(d, key, default=None):

--- a/nbstripout/_utils.py
+++ b/nbstripout/_utils.py
@@ -1,11 +1,22 @@
 from collections import defaultdict
 import sys
+from typing import NamedTuple, List, Any
+from nbformat import NotebookNode
 
-__all__ = ["pop_recursive", "strip_output", "strip_zeppelin_output", "MetadataError"]
+__all__ = ["pop_recursive", "strip_output", "strip_zeppelin_output", "StripArgs", "MetadataError"]
 
 
 class MetadataError(Exception):
     pass
+
+class StripArgs(NamedTuple):
+    keep_output: bool
+    keep_count: bool
+    extra_keys: List[str] = []
+    drop_empty_cells: bool = False
+    drop_tagged_cells: List[str] = []
+    strip_init_cells: bool = False
+    max_size:int = 0
 
 
 def pop_recursive(d, key, default=None):
@@ -29,7 +40,7 @@ def pop_recursive(d, key, default=None):
     return default
 
 
-def _cells(nb, conditionals):
+def _cells(nb: NotebookNode, conditionals):
     """Remove cells not satisfying any conditional in conditionals and yield all other cells."""
     if nb.nbformat < 4:
         for ws in nb.worksheets:
@@ -44,7 +55,7 @@ def _cells(nb, conditionals):
             yield cell
 
 
-def get_size(item):
+def get_size(item: Any):
     """ Recursively sums length of all strings in `item` """
     if isinstance(item, str):
         return len(item)
@@ -56,7 +67,7 @@ def get_size(item):
         return len(str(item))
 
 
-def determine_keep_output(cell, default, strip_init_cells=False):
+def determine_keep_output(cell: NotebookNode, default, strip_init_cells=False):
     """Given a cell, determine whether output should be kept
 
     Based on whether the metadata has "init_cell": true,
@@ -82,20 +93,19 @@ def determine_keep_output(cell, default, strip_init_cells=False):
     return default
 
 
-def _zeppelin_cells(nb):
+def _zeppelin_cells(nb: NotebookNode):
     for pg in nb['paragraphs']:
         yield pg
 
 
-def strip_zeppelin_output(nb):
+def strip_zeppelin_output(nb: NotebookNode):
     for cell in _zeppelin_cells(nb):
         if 'results' in cell:
             cell['results'] = {}
     return nb
 
 
-def strip_output(nb, keep_output, keep_count, extra_keys=[], drop_empty_cells=False, drop_tagged_cells=[],
-                 strip_init_cells=False, max_size=0):
+def strip_output(nb: NotebookNode, args: StripArgs):
     """
     Strip the outputs, execution count/prompt number and miscellaneous
     metadata from a notebook object, unless specified to keep either the outputs
@@ -103,11 +113,12 @@ def strip_output(nb, keep_output, keep_count, extra_keys=[], drop_empty_cells=Fa
 
     `extra_keys` could be 'metadata.foo cell.metadata.bar metadata.baz'
     """
-    if keep_output is None and 'keep_output' in nb.metadata:
+    keep_output = args.keep_output
+    if args.keep_output is None and 'keep_output' in nb.metadata:
         keep_output = bool(nb.metadata['keep_output'])
 
     keys = defaultdict(list)
-    for key in extra_keys:
+    for key in args.extra_keys:
         if '.' not in key or key.split('.')[0] not in ['cell', 'metadata']:
             sys.stderr.write(f'Ignoring invalid extra key `{key}`\n')
         else:
@@ -119,13 +130,13 @@ def strip_output(nb, keep_output, keep_count, extra_keys=[], drop_empty_cells=Fa
 
     conditionals = []
     # Keep cells if they have any `source` line that contains non-whitespace
-    if drop_empty_cells:
+    if args.drop_empty_cells:
         conditionals.append(lambda c: any(line.strip() for line in c.get('source', [])))
-    for tag_to_drop in drop_tagged_cells:
+    for tag_to_drop in args.drop_tagged_cells:
         conditionals.append(lambda c: tag_to_drop not in c.get("metadata", {}).get("tags", []))
 
     for cell in _cells(nb, conditionals):
-        keep_output_this_cell = determine_keep_output(cell, keep_output, strip_init_cells)
+        keep_output_this_cell = determine_keep_output(cell, keep_output, args.strip_init_cells)
 
         # Remove the outputs, unless directed otherwise
         if 'outputs' in cell:
@@ -133,10 +144,10 @@ def strip_output(nb, keep_output, keep_count, extra_keys=[], drop_empty_cells=Fa
             # Default behavior (max_size == 0) strips all outputs.
             if not keep_output_this_cell:
                 cell['outputs'] = [output for output in cell['outputs']
-                                   if get_size(output) <= max_size]
+                                   if get_size(output) <= args.max_size]
 
             # Strip the counts from the outputs that were kept if not keep_count.
-            if not keep_count:
+            if not args.keep_count:
                 for output in cell['outputs']:
                     if 'execution_count' in output:
                         output['execution_count'] = None
@@ -144,9 +155,9 @@ def strip_output(nb, keep_output, keep_count, extra_keys=[], drop_empty_cells=Fa
             # If keep_output_this_cell and keep_count, do nothing.
 
         # Remove the prompt_number/execution_count, unless directed otherwise
-        if 'prompt_number' in cell and not keep_count:
+        if 'prompt_number' in cell and not args.keep_count:
             cell['prompt_number'] = None
-        if 'execution_count' in cell and not keep_count:
+        if 'execution_count' in cell and not args.keep_count:
             cell['execution_count'] = None
 
         # Always remove some metadata

--- a/tests/test_keep_output_tags.py
+++ b/tests/test_keep_output_tags.py
@@ -5,7 +5,7 @@ import re
 import nbformat
 import pytest
 
-from nbstripout import strip_output, MetadataError
+from nbstripout import strip_output, StripArgs, MetadataError
 
 directory = os.path.dirname(__file__)
 
@@ -24,7 +24,8 @@ def nb_with_exception():
 
 def test_cells(orig_nb):
     nb_stripped = deepcopy(orig_nb)
-    nb_stripped = strip_output(nb_stripped, None, None)
+    strip_args = StripArgs(False, False)
+    nb_stripped = strip_output(nb_stripped, strip_args)
     for i, cell in enumerate(nb_stripped.cells):
         if cell.cell_type == 'code' and cell.source:
             match = re.match(r"\s*#\s*(output|no_output)", cell.source)
@@ -41,4 +42,5 @@ def test_cells(orig_nb):
 
 def test_exception(nb_with_exception):
     with pytest.raises(MetadataError):
-        strip_output(nb_with_exception, None, None)
+        strip_args = StripArgs(False, False)
+        strip_output(nb_with_exception, strip_args)


### PR DESCRIPTION
Separate concerns and reduce duplicate code by creating methods.

This will better facilitate future improvements to make nbstripout more flexible, such as:
- making configuration easier to manage to facilitate reading from other sources such as tox.ini or pyproject.toml
- create a --check mode
- running nbstripout as part of a ci pipeline

Doing a dummpy PR in my own fork for now, while I get the hang of this project.